### PR TITLE
Add gdbus-codegen dependency to flatpak ebuild

### DIFF
--- a/sys-apps/flatpak/flatpak-0.6.12.ebuild
+++ b/sys-apps/flatpak/flatpak-0.6.12.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	>=sys-devel/gettext-0.18.2
 	>=dev-util/pkgconfig-0.24
+	dev-util/gdbus-codegen
 	introspection? ( >=dev-libs/gobject-introspection-1.40 )
 	doc? ( >=dev-util/gtk-doc-1.20
 	       dev-libs/libxslt )


### PR DESCRIPTION
It's required during compilation, so emerging without it fails.
