### PR TITLE
sys-apps/flatpak: fixed localstatedir.

### DIFF
--- a/sys-apps/flatpak/flatpak-0.8.0.ebuild
+++ b/sys-apps/flatpak/flatpak-0.8.0.ebuild
@@ -56,6 +56,7 @@ src_configure() {
 	# FIXME: the gtk-doc check doesn't seem to be working
 	# FIXME: split out bubblewrap
 	econf \
+		--localstatedir="${EPREFIX}"/var \
 		--enable-sandboxed-triggers \
 		--enable-xauth \
 		--without-system-bubblewrap \


### PR DESCRIPTION
Previously it was placing stuff in `/var/lib/lib/flatpak`