### PR TITLE
clone via https, not insecure git

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For the [local repository](https://wiki.gentoo.org/wiki/Handbook:Parts/Portage/C
 priority = 50
 location = <repo-location>/flatpak-overlay
 sync-type = git
-sync-uri = git://github.com/fosero/flatpak-overlay.git
+sync-uri = https://github.com/fosero/flatpak-overlay.git
 auto-sync = Yes
 ```
 


### PR DESCRIPTION
Change the URL from git:// to https://.
The git:// protocol provides no security of the transmitted files and should be avoided. It allows a man in the middle attacker to inject arbitrary code or malicious ebuilds.