### PR TITLE
Add flatpak group and user creation to pkg_setup

### DIFF
--- a/sys-apps/flatpak/flatpak-1.4.0.ebuild
+++ b/sys-apps/flatpak/flatpak-1.4.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 
-inherit autotools linux-info
+inherit autotools linux-info user
 
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/${PV}/${P}.tar.xz"
 DESCRIPTION="Application distribution framework"

--- a/sys-apps/flatpak/flatpak-1.4.0.ebuild
+++ b/sys-apps/flatpak/flatpak-1.4.0.ebuild
@@ -52,6 +52,9 @@ PDEPEND="
 
 pkg_setup() {
 
+	enewgroup flatpak
+	enewuser flatpak -1 -1 -1 flatpak
+
 	local CONFIG_CHECK="~USER_NS"
 	linux-info_pkg_setup
 


### PR DESCRIPTION
https://github.com/flatpak/flatpak/issues/2959

Pending an answer from upstream on what the `flatpak` user actually needs to be able to do. I'm not sure whether it requires a group either.